### PR TITLE
Add predict_win/1 and tau-based rating adjustments

### DIFF
--- a/lib/openskill.ex
+++ b/lib/openskill.ex
@@ -52,11 +52,33 @@ defmodule Openskill do
     defaults = [
       weights: Util.default_weights(rating_groups),
       ranks: Util.default_ranks(rating_groups),
-      model: Openskill.PlackettLuce
+      model: Openskill.PlackettLuce,
+      tau: @env.tau,
+      prevent_sigma_increase: @env.prevent_sigma_increase
     ]
 
     options = Keyword.merge(defaults, options) |> Enum.into(%{})
-    options.model.rate(rating_groups, options)
+
+    rating_groups_with_tau =
+      Enum.map(rating_groups, fn team ->
+        Enum.map(team, fn {mu, sigma} ->
+          {mu, Math.sqrt(sigma ** 2 + options.tau ** 2)}
+        end)
+      end)
+
+    output = options.model.rate(rating_groups_with_tau, options)
+
+    if options.tau > 0 and options.prevent_sigma_increase do
+      Enum.zip(rating_groups, output)
+      |> Enum.map(fn {old_team, new_team} ->
+        Enum.zip(old_team, new_team)
+        |> Enum.map(fn {{_old_mu, old_sigma}, {new_mu, new_sigma}} ->
+          {new_mu, min(old_sigma, new_sigma)}
+        end)
+      end)
+    else
+      output
+    end
   end
 
   @doc """
@@ -120,5 +142,46 @@ defmodule Openskill do
     else
       result
     end
+  end
+
+  @doc """
+  Predict the win probability for each team. Returns a list of probabilities
+  in the same order as the input teams; the values sum to 1.
+
+  ## Examples
+
+      iex> teams = [
+      ...>   [{25, 8.333}, {30, 6.666}],
+      ...>   [{27, 7.0}, {28, 5.5}]
+      ...> ]
+      iex> Openskill.predict_win(teams)
+      [0.5000000005, 0.5000000005]
+
+  When the sum of mu is equal across teams, the result is ~50% per team
+  regardless of the sigmas. Increasing the mu of one team raises that team's
+  predicted win probability; increasing the uncertainty of any team moves
+  the result closer to 50%.
+  """
+  @spec predict_win([[mu_sigma_pair()]]) :: [float()]
+  def predict_win(teams) do
+    team_ratings = Util.team_rating(teams)
+    n = length(teams)
+    denom = n * (n - 1) / 2
+    betasq = @env.beta * @env.beta
+
+    team_ratings
+    |> Enum.with_index()
+    |> Enum.map(fn {{mu_a, sigma_sq_a, _team, _i}, i} ->
+      sum =
+        team_ratings
+        |> Enum.with_index()
+        |> Enum.filter(fn {_, q} -> i != q end)
+        |> Enum.map(fn {{mu_b, sigma_sq_b, _team, _i}, _} ->
+          Util.phi_major((mu_a - mu_b) / :math.sqrt(n * betasq + sigma_sq_a + sigma_sq_b))
+        end)
+        |> Enum.sum()
+
+      sum / denom
+    end)
   end
 end

--- a/lib/openskill/environment.ex
+++ b/lib/openskill/environment.ex
@@ -4,10 +4,14 @@ defmodule Openskill.Environment do
   @sigma @mu / @z
   @beta @sigma / 2
   @epsilon 0.0001
+  @tau 1 / 3
+  @prevent_sigma_increase false
 
   defstruct mu: @mu,
             sigma: @sigma,
             beta: @beta,
             epsilon: @epsilon,
-            z: @z
+            z: @z,
+            tau: @tau,
+            prevent_sigma_increase: @prevent_sigma_increase
 end

--- a/test/openskill_test.exs
+++ b/test/openskill_test.exs
@@ -39,7 +39,7 @@ defmodule OpenskillTest do
       c1 = Openskill.rating(16.672, 6.217)
       d1 = Openskill.rating()
 
-      [[a2], [b2], [c2], [d2]] = Openskill.rate([[a1], [b1], [c1], [d1]])
+      [[a2], [b2], [c2], [d2]] = Openskill.rate([[a1], [b1], [c1], [d1]], tau: 0)
 
       assert [
                [{30.209971908310553, 4.764898977359521}],
@@ -58,7 +58,8 @@ defmodule OpenskillTest do
       [[a2], [b2], [c2], [d2]] =
         Openskill.rate(
           [[a1], [b1], [c1], [d1]],
-          model: Openskill.BradleyTerryFull
+          model: Openskill.BradleyTerryFull,
+          tau: 0
         )
 
       assert [
@@ -78,7 +79,8 @@ defmodule OpenskillTest do
       [[a2], [b2], [c2], [d2]] =
         Openskill.rate(
           [[a1], [b1], [c1], [d1]],
-          model: Openskill.ThurstoneMostellerPart
+          model: Openskill.ThurstoneMostellerPart,
+          tau: 0
         )
 
       assert [
@@ -125,6 +127,100 @@ defmodule OpenskillTest do
         "c1" => {_, _},
         "d1" => {_, _}
       }, result)
+    end
+  end
+
+  describe "#rate with tau" do
+    test "default tau adds noise to sigma before rating" do
+      a1 = Openskill.rating(29.182, 4.782)
+      b1 = Openskill.rating(27.174, 4.922)
+      c1 = Openskill.rating(16.672, 6.217)
+      d1 = Openskill.rating()
+
+      [[a2], [b2], [c2], [d2]] = Openskill.rate([[a1], [b1], [c1], [d1]], tau: 0.01)
+
+      assert [
+               [{30.20997558824299, 4.764909330988368}],
+               [{27.64461002009721, 4.882799245921361}],
+               [{17.403587237635527, 6.100731158882956}],
+               [{19.21478808745494, 7.854267281042293}]
+             ] == [[a2], [b2], [c2], [d2]]
+    end
+
+    test "prevent_sigma_increase clamps post-rate sigma to be no larger than pre-rate sigma" do
+      a1 = Openskill.rating(6.672, 0.0001)
+      b1 = Openskill.rating(29.182, 4.782)
+
+      [[a2], [_b2]] = Openskill.rate([[a1], [b1]], tau: 0.01, prevent_sigma_increase: true)
+
+      {_a1_mu, a1_sigma} = a1
+      {_a2_mu, a2_sigma} = a2
+
+      assert a2_sigma <= a1_sigma
+    end
+  end
+
+  describe "#predict_win" do
+    test "equal team mu sums give equal win probability regardless of sigmas" do
+      teams = [
+        [{25, 8.333}, {30, 6.666}],
+        [{27, 7.0}, {28, 5.5}]
+      ]
+
+      assert [0.5000000005, 0.5000000005] = Openskill.predict_win(teams)
+    end
+
+    test "matches openskill.py reference output" do
+      # https://github.com/vivekjoshy/openskill.py/blob/main/docs/source/manual.rst#predicting-winners
+      teams = [
+        [{25, 25 / 3}],
+        [{33.564, 1.123}]
+      ]
+
+      assert [0.202122560771339, 0.797877439228661] = Openskill.predict_win(teams)
+    end
+
+    test "raising one team's mu raises that team's win probability" do
+      [equal_a, _equal_b] =
+        Openskill.predict_win([
+          [{50, 1}, {0, 6.666}],
+          [{25, 1}, {25, 5.5}]
+        ])
+
+      [advantaged_a, _disadvantaged_b] =
+        Openskill.predict_win([
+          [{50, 1}, {1, 6.666}],
+          [{25, 1}, {25, 5.5}]
+        ])
+
+      assert advantaged_a > equal_a
+    end
+
+    test "raising sigma on either side moves probability toward 50%" do
+      [base_a, _base_b] =
+        Openskill.predict_win([
+          [{50, 1}, {1, 6.666}],
+          [{25, 1}, {25, 5.5}]
+        ])
+
+      [noisier_a, _] =
+        Openskill.predict_win([
+          [{50, 8}, {1, 6.666}],
+          [{25, 1}, {25, 5.5}]
+        ])
+
+      assert abs(noisier_a - 0.5) < abs(base_a - 0.5)
+    end
+
+    test "probabilities sum to 1" do
+      teams = [
+        [{25, 8.333}],
+        [{30, 6.666}],
+        [{27, 7.0}]
+      ]
+
+      probabilities = Openskill.predict_win(teams)
+      assert_in_delta Enum.sum(probabilities), 1.0, 1.0e-9
     end
   end
 end


### PR DESCRIPTION
Superseded by #35 (predict_win) and #36 (tau / prevent_sigma_increase) — splitting the original combined PR per request.