### PR TITLE
Add predict_win/1

### DIFF
--- a/lib/openskill.ex
+++ b/lib/openskill.ex
@@ -121,4 +121,45 @@ defmodule Openskill do
       result
     end
   end
+
+  @doc """
+  Predict the win probability for each team. Returns a list of probabilities
+  in the same order as the input teams; the values sum to 1.
+
+  ## Examples
+
+      iex> teams = [
+      ...>   [{25, 8.333}, {30, 6.666}],
+      ...>   [{27, 7.0}, {28, 5.5}]
+      ...> ]
+      iex> Openskill.predict_win(teams)
+      [0.5000000005, 0.5000000005]
+
+  When the sum of mu is equal across teams, the result is ~50% per team
+  regardless of the sigmas. Increasing the mu of one team raises that team's
+  predicted win probability; increasing the uncertainty of any team moves
+  the result closer to 50%.
+  """
+  @spec predict_win([[mu_sigma_pair()]]) :: [float()]
+  def predict_win(teams) do
+    team_ratings = Util.team_rating(teams)
+    n = length(teams)
+    denom = n * (n - 1) / 2
+    betasq = @env.beta * @env.beta
+
+    team_ratings
+    |> Enum.with_index()
+    |> Enum.map(fn {{mu_a, sigma_sq_a, _team, _i}, i} ->
+      sum =
+        team_ratings
+        |> Enum.with_index()
+        |> Enum.filter(fn {_, q} -> i != q end)
+        |> Enum.map(fn {{mu_b, sigma_sq_b, _team, _i}, _} ->
+          Util.phi_major((mu_a - mu_b) / :math.sqrt(n * betasq + sigma_sq_a + sigma_sq_b))
+        end)
+        |> Enum.sum()
+
+      sum / denom
+    end)
+  end
 end

--- a/test/openskill_test.exs
+++ b/test/openskill_test.exs
@@ -127,4 +127,68 @@ defmodule OpenskillTest do
       }, result)
     end
   end
+
+  describe "#predict_win" do
+    test "equal team mu sums give equal win probability regardless of sigmas" do
+      teams = [
+        [{25, 8.333}, {30, 6.666}],
+        [{27, 7.0}, {28, 5.5}]
+      ]
+
+      assert [0.5000000005, 0.5000000005] = Openskill.predict_win(teams)
+    end
+
+    test "matches openskill.py reference output" do
+      # https://github.com/vivekjoshy/openskill.py/blob/main/docs/source/manual.rst#predicting-winners
+      teams = [
+        [{25, 25 / 3}],
+        [{33.564, 1.123}]
+      ]
+
+      assert [0.202122560771339, 0.797877439228661] = Openskill.predict_win(teams)
+    end
+
+    test "raising one team's mu raises that team's win probability" do
+      [equal_a, _equal_b] =
+        Openskill.predict_win([
+          [{50, 1}, {0, 6.666}],
+          [{25, 1}, {25, 5.5}]
+        ])
+
+      [advantaged_a, _disadvantaged_b] =
+        Openskill.predict_win([
+          [{50, 1}, {1, 6.666}],
+          [{25, 1}, {25, 5.5}]
+        ])
+
+      assert advantaged_a > equal_a
+    end
+
+    test "raising sigma on either side moves probability toward 50%" do
+      [base_a, _base_b] =
+        Openskill.predict_win([
+          [{50, 1}, {1, 6.666}],
+          [{25, 1}, {25, 5.5}]
+        ])
+
+      [noisier_a, _] =
+        Openskill.predict_win([
+          [{50, 8}, {1, 6.666}],
+          [{25, 1}, {25, 5.5}]
+        ])
+
+      assert abs(noisier_a - 0.5) < abs(base_a - 0.5)
+    end
+
+    test "probabilities sum to 1" do
+      teams = [
+        [{25, 8.333}],
+        [{30, 6.666}],
+        [{27, 7.0}]
+      ]
+
+      probabilities = Openskill.predict_win(teams)
+      assert_in_delta Enum.sum(probabilities), 1.0, 1.0e-9
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds `predict_win/1` — returns each team's win probability based on the sum of player mu and sigma. Probabilities sum to 1.

```elixir
iex> teams = [[{25, 25/3}], [{33.564, 1.123}]]
iex> Openskill.predict_win(teams)
[0.202122560771339, 0.797877439228661]
```

The output for the single-player example matches the reference [openskill.py output](https://github.com/vivekjoshy/openskill.py/blob/main/docs/source/manual.rst#predicting-winners). Reuses the existing `Openskill.Util.phi_major/1` rather than duplicating a phi_major helper.

Refs #24. Ports the `predict_win` portions of [@Jonovono's](https://github.com/Jonovono/openskill.ex) and [@jauggy's](https://github.com/jauggy/openskill.ex) forks.

This is one of two PRs splitting the original combined PR (#34); the tau changes are in a separate PR.

## Test plan
- [ ] CI green.
- [ ] New tests cover: matching openskill.py reference, equal-mu symmetry, monotonicity in mu, sigma pulling probability toward 50%, and probabilities summing to 1.

https://claude.ai/code/session_01ERaHZhCVGUbPVrsME9dVU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERaHZhCVGUbPVrsME9dVU1)_