### PR TITLE
Add tau and prevent_sigma_increase options to rate/2

### DIFF
--- a/lib/openskill.ex
+++ b/lib/openskill.ex
@@ -52,11 +52,33 @@ defmodule Openskill do
     defaults = [
       weights: Util.default_weights(rating_groups),
       ranks: Util.default_ranks(rating_groups),
-      model: Openskill.PlackettLuce
+      model: Openskill.PlackettLuce,
+      tau: @env.tau,
+      prevent_sigma_increase: @env.prevent_sigma_increase
     ]
 
     options = Keyword.merge(defaults, options) |> Enum.into(%{})
-    options.model.rate(rating_groups, options)
+
+    rating_groups_with_tau =
+      Enum.map(rating_groups, fn team ->
+        Enum.map(team, fn {mu, sigma} ->
+          {mu, Math.sqrt(sigma ** 2 + options.tau ** 2)}
+        end)
+      end)
+
+    output = options.model.rate(rating_groups_with_tau, options)
+
+    if options.tau > 0 and options.prevent_sigma_increase do
+      Enum.zip(rating_groups, output)
+      |> Enum.map(fn {old_team, new_team} ->
+        Enum.zip(old_team, new_team)
+        |> Enum.map(fn {{_old_mu, old_sigma}, {new_mu, new_sigma}} ->
+          {new_mu, min(old_sigma, new_sigma)}
+        end)
+      end)
+    else
+      output
+    end
   end
 
   @doc """

--- a/lib/openskill/environment.ex
+++ b/lib/openskill/environment.ex
@@ -4,10 +4,14 @@ defmodule Openskill.Environment do
   @sigma @mu / @z
   @beta @sigma / 2
   @epsilon 0.0001
+  @tau 1 / 3
+  @prevent_sigma_increase false
 
   defstruct mu: @mu,
             sigma: @sigma,
             beta: @beta,
             epsilon: @epsilon,
-            z: @z
+            z: @z,
+            tau: @tau,
+            prevent_sigma_increase: @prevent_sigma_increase
 end

--- a/test/openskill_test.exs
+++ b/test/openskill_test.exs
@@ -39,7 +39,7 @@ defmodule OpenskillTest do
       c1 = Openskill.rating(16.672, 6.217)
       d1 = Openskill.rating()
 
-      [[a2], [b2], [c2], [d2]] = Openskill.rate([[a1], [b1], [c1], [d1]])
+      [[a2], [b2], [c2], [d2]] = Openskill.rate([[a1], [b1], [c1], [d1]], tau: 0)
 
       assert [
                [{30.209971908310553, 4.764898977359521}],
@@ -58,7 +58,8 @@ defmodule OpenskillTest do
       [[a2], [b2], [c2], [d2]] =
         Openskill.rate(
           [[a1], [b1], [c1], [d1]],
-          model: Openskill.BradleyTerryFull
+          model: Openskill.BradleyTerryFull,
+          tau: 0
         )
 
       assert [
@@ -78,7 +79,8 @@ defmodule OpenskillTest do
       [[a2], [b2], [c2], [d2]] =
         Openskill.rate(
           [[a1], [b1], [c1], [d1]],
-          model: Openskill.ThurstoneMostellerPart
+          model: Openskill.ThurstoneMostellerPart,
+          tau: 0
         )
 
       assert [
@@ -189,6 +191,36 @@ defmodule OpenskillTest do
 
       probabilities = Openskill.predict_win(teams)
       assert_in_delta Enum.sum(probabilities), 1.0, 1.0e-9
+    end
+  end
+
+  describe "#rate with tau" do
+    test "default tau adds noise to sigma before rating" do
+      a1 = Openskill.rating(29.182, 4.782)
+      b1 = Openskill.rating(27.174, 4.922)
+      c1 = Openskill.rating(16.672, 6.217)
+      d1 = Openskill.rating()
+
+      [[a2], [b2], [c2], [d2]] = Openskill.rate([[a1], [b1], [c1], [d1]], tau: 0.01)
+
+      assert [
+               [{30.20997558824299, 4.764909330988368}],
+               [{27.64461002009721, 4.882799245921361}],
+               [{17.403587237635527, 6.100731158882956}],
+               [{19.21478808745494, 7.854267281042293}]
+             ] == [[a2], [b2], [c2], [d2]]
+    end
+
+    test "prevent_sigma_increase clamps post-rate sigma to be no larger than pre-rate sigma" do
+      a1 = Openskill.rating(6.672, 0.0001)
+      b1 = Openskill.rating(29.182, 4.782)
+
+      [[a2], [_b2]] = Openskill.rate([[a1], [b1]], tau: 0.01, prevent_sigma_increase: true)
+
+      {_a1_mu, a1_sigma} = a1
+      {_a2_mu, a2_sigma} = a2
+
+      assert a2_sigma <= a1_sigma
     end
   end
 end


### PR DESCRIPTION
## Summary

Adds `tau` and `prevent_sigma_increase` options to `Openskill.rate/2`, aligning the algorithm with openskill.py.

- `Openskill.Environment` gains `tau` (default `1/3`) and `prevent_sigma_increase` (default `false`).
- `Openskill.rate/2` now applies `sqrt(sigma² + tau²)` to each player's sigma before delegating to the model. This keeps sigma from collapsing toward zero over many games and matches the canonical algorithm.
- When `tau > 0` and `prevent_sigma_increase: true`, post-rate sigmas are clamped to be no larger than pre-rate sigmas — useful when you need tau for numerical health but don't want a player's uncertainty to grow.

### Behavioral note
Default `tau = 1/3` is a numerical change from the previous behavior (effectively `tau = 0`). Existing `#rate` tests now pass `tau: 0` explicitly so their hardcoded expected outputs still hold; existing users who depend on byte-exact outputs can do the same.

Refs #24. Ports the tau work from [@jauggy's fork](https://github.com/jauggy/openskill.ex) (originally from @StanczakDominik).

This is one of two PRs splitting the original combined PR (#34); `predict_win` is in #35.

## Test plan
- [ ] CI green.
- [ ] New tests cover: tau changing rate output, and `prevent_sigma_increase` clamping sigma.

https://claude.ai/code/session_01ERaHZhCVGUbPVrsME9dVU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERaHZhCVGUbPVrsME9dVU1)_