### PR TITLE
Plackett-Luce: bit-for-bit parity with openskill.js

### DIFF
--- a/lib/openskill/plackett_luce.ex
+++ b/lib/openskill/plackett_luce.ex
@@ -3,73 +3,63 @@ defmodule Openskill.PlackettLuce do
 
   @env %Environment{}
   @betasq @env.beta * @env.beta
+  @kappa @env.epsilon
 
   def rate(game, _options \\ []) do
     team_ratings = Util.team_rating(game)
 
     c =
-      Enum.map(team_ratings, fn {_, team_sigmasq, _, _} ->
-        team_sigmasq + @betasq
-      end)
+      team_ratings
+      |> Enum.map(fn {_, team_sigmasq, _, _} -> team_sigmasq + @betasq end)
       |> Enum.sum()
       |> Math.sqrt()
 
     sum_q =
-      team_ratings
-      |> Enum.map(fn {_, _, _, teamq_rank} ->
+      Enum.map(team_ratings, fn {_, _, _, q_rank} ->
         team_ratings
-        |> Enum.filter(fn {_, _, _, teami_rank} -> teami_rank >= teamq_rank end)
-        |> Enum.map(fn {teami_mu, _, _, _} ->
-          Math.exp(teami_mu / c)
-        end)
+        |> Enum.filter(fn {_, _, _, i_rank} -> i_rank >= q_rank end)
+        |> Enum.map(fn {i_mu, _, _, _} -> Math.exp(i_mu / c) end)
         |> Enum.sum()
       end)
-      |> Enum.with_index(1)
-      |> Enum.map(fn {k, v} -> {v, k} end)
-      |> Map.new()
 
     a =
-      team_ratings
-      |> Enum.map(fn {_, _, _, teami_rank} ->
-        team_ratings
-        |> Enum.filter(fn {_, _, _, teamq_rank} -> teami_rank == teamq_rank end)
-        |> Enum.count()
+      Enum.map(team_ratings, fn {_, _, _, q_rank} ->
+        Enum.count(team_ratings, fn {_, _, _, i_rank} -> i_rank == q_rank end)
       end)
-      |> Enum.with_index(1)
-      |> Enum.map(fn {k, v} -> {v, k} end)
-      |> Map.new()
+
+    indexed_q =
+      team_ratings
+      |> Enum.zip(sum_q)
+      |> Enum.zip(a)
+      |> Enum.with_index()
+      |> Enum.map(fn {{{tr, sum_q_q}, a_q}, q} -> {tr, sum_q_q, a_q, q} end)
 
     team_ratings
-    |> Enum.map(fn {teami_mu, teami_sigmasq, teami, teami_rank} ->
-      tmp1 = Math.exp(teami_mu / c)
+    |> Enum.with_index()
+    |> Enum.map(fn {{i_mu, i_sigmasq, i_team, i_rank}, i} ->
+      i_mu_over_ce = Math.exp(i_mu / c)
 
-      {omega_set, delta_set} =
-        team_ratings
-        |> Enum.filter(fn {_, _, _, teamq_rank} -> teamq_rank <= teami_rank end)
-        |> Enum.map(fn {_, _, _, teamq_rank} ->
-          tmp = tmp1 / sum_q[teamq_rank]
-
-          {
-            if teamq_rank == teami_rank do
-              1 - tmp / a[teamq_rank]
-            else
-              -tmp / a[teamq_rank]
-            end,
-            tmp * (1 - tmp) / a[teamq_rank]
-          }
+      {omega_sum, delta_sum} =
+        Enum.reduce(indexed_q, {0, 0}, fn {{_, _, _, q_rank}, sum_q_q, a_q, q}, {omega, delta} ->
+          if q_rank > i_rank do
+            {omega, delta}
+          else
+            quotient = i_mu_over_ce / sum_q_q
+            term = if i == q, do: 1 - quotient, else: -quotient
+            {omega + term / a_q, delta + quotient * (1 - quotient) / a_q}
+          end
         end)
-        |> Enum.unzip()
 
-      gamma = Math.sqrt(teami_sigmasq) / c
-      omegai = Enum.sum(omega_set) * teami_sigmasq / c
-      deltai = gamma * Enum.sum(delta_set) * teami_sigmasq / c / c
+      i_gamma = Math.sqrt(i_sigmasq) / c
+      i_omega = omega_sum * (i_sigmasq / c)
+      i_delta = delta_sum * (i_sigmasq / (c * c)) * i_gamma
 
-      for {muij, sigmaij} <- teami do
-        sigmaijsq = sigmaij * sigmaij
+      for {mu, sigma} <- i_team do
+        sigma_sq = sigma * sigma
 
         {
-          muij + sigmaijsq / teami_sigmasq * omegai,
-          sigmaij * Math.sqrt(max(1 - sigmaijsq / teami_sigmasq * deltai, @env.epsilon))
+          mu + sigma_sq / i_sigmasq * i_omega,
+          sigma * Math.sqrt(max(1 - sigma_sq / i_sigmasq * i_delta, @kappa))
         }
       end
     end)

--- a/test/openskill_test.exs
+++ b/test/openskill_test.exs
@@ -194,6 +194,46 @@ defmodule OpenskillTest do
     end
   end
 
+  describe "#rate Plackett-Luce parity with openskill.js" do
+    # Reference values are produced by openskill.js v6.x which itself is
+    # bit-for-bit aligned with openskill.py 6.x. Both expected outputs
+    # below were generated with the openskill.js default tau (25/300).
+
+    test "doubles match" do
+      inputs = [
+        [{29.182, 4.782}, {27.174, 4.922}],
+        [{16.672, 6.217}, {25.0, 25 / 3}]
+      ]
+
+      assert [
+               [
+                 {29.607340941337068, 4.755311788972862},
+                 {27.624602782532037, 4.892807828777459}
+               ],
+               [
+                 {15.953170429143093, 6.125902065139878},
+                 {23.70858117648013, 8.111707446126035}
+               ]
+             ] == Openskill.rate(inputs, tau: 25 / 300)
+    end
+
+    test "four-way free-for-all" do
+      inputs = [
+        [{29.182, 4.782}],
+        [{27.174, 4.922}],
+        [{16.672, 6.217}],
+        [{25.0, 25 / 3}]
+      ]
+
+      assert [
+               [{30.210227447000438, 4.765617924939384}],
+               [{27.644725221915632, 4.883479590134575}],
+               [{17.4036218889969, 6.101259408259549}],
+               [{19.21460876538932, 7.854669920480409}]
+             ] == Openskill.rate(inputs, tau: 25 / 300)
+    end
+  end
+
   describe "#rate with tau" do
     test "default tau adds noise to sigma before rating" do
       a1 = Openskill.rating(29.182, 4.782)


### PR DESCRIPTION
## Summary

Makes `Openskill.PlackettLuce` produce **bit-for-bit identical** output to [openskill.js](https://github.com/philihp/openskill.js)'s `plackett-luce` model (which itself is bit-for-bit aligned with openskill.py 6.x).

### Algorithmic changes
1. **`sum_q` and `a` are now indexed by team position rather than rank value.** The previous code built these as maps keyed by `with_index(1)` (team position) but read them with `sum_q[teamq_rank]` (rank value). Those keys only line up when ranks happen to be `1..n` in input order — for any other rank arrangement, the lookup silently returned a value belonging to a different team.
2. **The omega "self-team" branch now compares team indices (`i == q`)** rather than rank values. This matters for tied-rank cases: openskill.js treats only the team itself as "self" even when other teams share its rank, whereas the previous Elixir code treated all tied teams as "self" relative to each other.

The math operations and grouping match openskill.js exactly so that floating-point rounding is identical.

### Test changes
- All existing `Openskill.PlackettLuce` model tests reproduce the same numbers (verified locally) — the bug was only triggered by non-default rank arrangements which our tests don't exercise.
- Existing `Openskill.rate` tests with `tau: 0` are unchanged.
- Adds parity tests that pass `tau: 25/300` (openskill.js / openskill.py default) and assert exact equality against openskill.js reference outputs for:
  - a doubles match with `rank: [1, 2]`
  - a four-way free-for-all at default ranks

### Out of scope
- The 16-match parity test from openskill.js (which uses `mu: 0, sigma: 1` overrides) requires per-call environment overrides we don't support yet — that's a separate change.
- Bradley-Terry and Thurstone-Mosteller likely have the same index-vs-rank bug; addressing them is a separate PR.

## Test plan
- [ ] CI green.
- [x] Locally verified: my port reproduces openskill.js outputs to all 17 significant figures for both new parity scenarios.
- [x] Locally verified: existing tests (`tau: 0` rate, all `Openskill.PlackettLuce` model tests) produce identical numbers to before.

https://claude.ai/code/session_01ERaHZhCVGUbPVrsME9dVU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERaHZhCVGUbPVrsME9dVU1)_